### PR TITLE
Arbitrary search filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,21 +30,19 @@ The server configuration must be a simple JSON file.
 ```js
 {
   "port": 3004, // The port the server will listen to (default to 3004)
-  "userLoginAttribute": "cn", // The name of the LDAP attribute holding the user login (default to cn)
   "searchBase": "dc=test" // The search base used by the client to fetch user trying to connect (default to dc=test)
 }
 ```
 
 ## LDAP users
 
-The database user must be a simple JSON file containing an array of users. Each user must have an attribute used to authenticate himself with the same name as defined by server configuration **userLoginAttribute**.
+The database user must be a simple JSON file containing an array of users. The user must have a valid distinguished name (dn).
 A user can also have any number of other attributes which will all be returned.
 
 ```js
 [
   {
     "dn": "cn=user,dc=test", // A valid DN (Distinguished Name)
-    "cn": "user-login", // The attribute corresponding to server configuration "userLoginAttribute"
     "attribute1": "value1",
     "attribute2": "value2",
     [...]

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ The server configuration must be a simple JSON file.
 {
   "port": 3004, // The port the server will listen to (default to 3004)
   "userLoginAttribute": "cn", // The name of the LDAP attribute holding the user login (default to cn)
-  "searchBase": "dc=test", // The search base used by the client to fetch user trying to connect (default to dc=test)
-  "searchFilter": "(&(objectclass=person)(cn={{username}}))" // The search filter used to fetch user trying to connect with the placeholder {{username}} (default to (&(objectclass=person)(cn={{username}})))
+  "searchBase": "dc=test" // The search base used by the client to fetch user trying to connect (default to dc=test)
 }
 ```
 
@@ -63,7 +62,7 @@ With:
  - **-x** to deactivate authentication to the LDAP server
  - **-H ldap://127.0.0.1:3004** the server URL
  - **-b "dc=test"** the search base in LDAP directory, it should be the same as the **searchBase** property in server configuration above
- - **"(&(objectclass=person)(cn=user-login))"** the search filter, it should be the same as the **searchFilter** property in server configuration with **{{username}}** replaced by the user login
+ - **"(&(objectclass=person)(cn=user-login))"** the search filter
  - **attribute1, attribute2** the list of attributes you want to be returned
 
 # Contributors

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ A user can also have any number of other attributes which will all be returned.
 [
   {
     "dn": "cn=user,dc=test", // A valid DN (Distinguished Name)
+    "objectClass": "person",
+    "cn": "user-login",
     "attribute1": "value1",
     "attribute2": "value2",
     [...]

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -9,77 +9,6 @@
 
 const databaseProvider = process.require('lib/databaseProvider.js');
 
-const splitFilter = (filter) => {
-  const parts = [];
-
-  let parenCount = 0;
-  let start = 0;
-  Array.from(filter).forEach((char, i) => {
-    if (char === '(') {
-      parenCount++;
-    } else if (char === ')') {
-      parenCount--;
-    }
-
-    if (parenCount === 0) {
-      parts.push(filter.substring(start, i + 1));
-      start = i + 1;
-    }
-  });
-
-  return parts;
-};
-
-const deduplicate = (entries) => {
-  const unique = [];
-  entries.forEach((entry) => {
-    if (!unique.some((item) => item.dn === entry.dn)) {
-      unique.push(entry);
-    }
-  });
-
-  return unique;
-};
-
-const getIntersection = (results) => {
-  if (results.length < 1) {
-    return results;
-  }
-
-  const intersection = results[0];
-  for (const entries of results.slice(1)) {
-    for (const entry of entries) {
-      const idx = intersection.findIndex((item) => item.dn === entry.dn);
-      if (idx === -1) {
-        intersection.splice(idx, 1);
-      }
-    }
-  }
-
-  return intersection;
-};
-
-const search = (filter) => {
-  const withoutParens = filter.substring(1, filter.length - 1);
-
-  if (withoutParens.startsWith('&')) {
-    return getIntersection(splitFilter(withoutParens.substring(1)).map(search));
-  } else if (withoutParens.startsWith('|')) {
-    return deduplicate(splitFilter(withoutParens.substring(1)).map(search).flat());
-  } else if (withoutParens.startsWith('!')) {
-    const filteredDns = search(withoutParens.substring(1)).map((user) => user.dn);
-    return databaseProvider.getAllUsers()
-      .filter((user) => !filteredDns.includes(user.dn));
-  } else {
-    // we do this instead of just .split('=') because filters can have "=" in the values
-    const equalSignIndex = withoutParens.indexOf('=');
-    const attributeName = withoutParens.substring(0, equalSignIndex);
-    const attributeValue = withoutParens.substring(equalSignIndex + 1);
-
-    return databaseProvider.getUsers(attributeName, attributeValue);
-  }
-};
-
 /**
  * Authenticates a user.
  *
@@ -96,10 +25,9 @@ module.exports.bindAction = (request, response) => {
 };
 
 /**
- * Searches for a particular user.
+ * Search for users.
  *
- * This is a mock, no verification is performed. User login is retrieved from searchFilter parameter using
- * the searchFilter from server configuration.
+ * This is a mock, no verification is performed. Users are filtered based on the filter.
  *
  * @method searchAction
  * @static
@@ -111,6 +39,6 @@ module.exports.bindAction = (request, response) => {
 module.exports.searchAction = (request, response) => {
   const searchFilter = request.filter.toString();
 
-  search(searchFilter).forEach((user) => response.send(user));
+  databaseProvider.search(searchFilter).forEach((user) => response.send(user));
   response.end();
 };

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -8,7 +8,77 @@
  */
 
 const databaseProvider = process.require('lib/databaseProvider.js');
-const conf = process.require('lib/conf.js');
+
+const splitFilter = (filter) => {
+  const parts = [];
+
+  let parenCount = 0;
+  let start = 0;
+  Array.from(filter).forEach((char, i) => {
+    if (char === '(') {
+      parenCount++;
+    } else if (char === ')') {
+      parenCount--;
+    }
+
+    if (parenCount === 0) {
+      parts.push(filter.substring(start, i + 1));
+      start = i + 1;
+    }
+  });
+
+  return parts;
+};
+
+const deduplicate = (entries) => {
+  const unique = [];
+  entries.forEach((entry) => {
+    if (!unique.some((item) => item.dn === entry.dn)) {
+      unique.push(entry);
+    }
+  });
+
+  return unique;
+};
+
+const getIntersection = (results) => {
+  if (results.length < 1) {
+    return results;
+  }
+
+  const intersection = results[0];
+  for (const entries of results.slice(1)) {
+    for (const entry of entries) {
+      const idx = intersection.findIndex((item) => item.dn === entry.dn);
+      if (idx === -1) {
+        intersection.splice(idx, 1);
+      }
+    }
+  }
+
+  return intersection;
+};
+
+const search = (filter) => {
+  const withoutParens = filter.substring(1, filter.length - 1);
+
+  if (withoutParens.startsWith('&')) {
+    return getIntersection(splitFilter(withoutParens.substring(1)).map(search));
+  } else if (withoutParens.startsWith('|')) {
+    return deduplicate(splitFilter(withoutParens.substring(1)).map(search).flat());
+  } else if (withoutParens.startsWith('!')) {
+    const filteredDns = search(withoutParens.substring(1)).map((user) => user.dn);
+    return databaseProvider.getAllUsers()
+      .filter((user) => !filteredDns.includes(user.dn));
+  } else {
+    // we do this instead of just .split('=') because filters can have "=" in the values
+    const equalSignIndex = withoutParens.indexOf('=');
+    const attributeName = withoutParens.substring(0, equalSignIndex);
+    const attributeValue = withoutParens.substring(equalSignIndex + 1);
+
+    return databaseProvider.getUsers(attributeName, attributeValue);
+  }
+};
 
 /**
  * Authenticates a user.
@@ -39,17 +109,8 @@ module.exports.bindAction = (request, response) => {
  * @param {SearchResponse} response LDAP response
  */
 module.exports.searchAction = (request, response) => {
-  const filterPattern = conf.server.searchFilter;
   const searchFilter = request.filter.toString();
 
-  // Extract user login name from search filter based on server configuration
-  const numberOfCharactersBefore = filterPattern.indexOf('{{');
-  const numberOfCharactersAfter = filterPattern.length - (filterPattern.indexOf('}}') + 2);
-  const userName = searchFilter.slice(numberOfCharactersBefore, searchFilter.length - numberOfCharactersAfter);
-  const user = databaseProvider.getUser(userName);
-
-  if (user)
-    response.send(user);
-
+  search(searchFilter).forEach((user) => response.send(user));
   response.end();
 };

--- a/lib/databaseProvider.js
+++ b/lib/databaseProvider.js
@@ -29,18 +29,16 @@ const deduplicate = (entries) => {
 };
 
 const getIntersection = (results) => {
-  if (results.length < 1) {
-    return results;
-  }
-
-  const intersection = results[0];
-  for (const entries of results.slice(1)) {
+  let intersection = results.shift();
+  for (const entries of results) {
+    const newIntersection = [];
     for (const entry of entries) {
-      const idx = intersection.findIndex((item) => item.dn === entry.dn);
-      if (idx === -1) {
-        intersection.splice(idx, 1);
+      if (intersection.some((item) => item.dn === entry.dn)) {
+        newIntersection.push(entry);
       }
     }
+
+    intersection = newIntersection;
   }
 
   return intersection;

--- a/lib/databaseProvider.js
+++ b/lib/databaseProvider.js
@@ -10,6 +10,14 @@
 const database = process.require('lib/database.js');
 const conf = process.require('lib/conf.js');
 
+const getWithNormalizedKey = (obj, normalizedKey) => {
+  for (const [key, value] of Object.entries(obj)) {
+    if (key.toLowerCase() === normalizedKey) {
+      return value;
+    }
+  }
+};
+
 /**
  * Fetches user from database.
  *
@@ -42,4 +50,24 @@ module.exports.getUser = (login) => {
   }
 
   return user;
+};
+
+module.exports.getAllUsers = () => {
+  return database.users.map((user) => {
+    const {dn, ...attributes} = user;
+    return {dn, attributes};
+  });
+};
+
+module.exports.getUsers = (attributeName, searchValue) => {
+  return database.users
+    .filter((user) => {
+      const searchRegex = new RegExp(`^${searchValue.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace('*', '.*')}$`);
+      const value = getWithNormalizedKey(user, attributeName);
+      return Array.isArray(value) ? value.some((item) => searchRegex.test(item)) : searchRegex.test(value);
+    })
+    .map((user) => {
+      const {dn, ...attributes} = user;
+      return {dn, attributes};
+    });
 };

--- a/lib/databaseProvider.js
+++ b/lib/databaseProvider.js
@@ -8,7 +8,6 @@
  */
 
 const database = process.require('lib/database.js');
-const conf = process.require('lib/conf.js');
 
 const getWithNormalizedKey = (obj, normalizedKey) => {
   for (const [key, value] of Object.entries(obj)) {
@@ -18,48 +17,64 @@ const getWithNormalizedKey = (obj, normalizedKey) => {
   }
 };
 
-/**
- * Fetches user from database.
- *
- * User attribute containing the login is defined by the userLoginAttribute property of the server configuration.
- *
- * @method getUser
- * @static
- * @params {String} login User login
- * @return {Object} The user as is
- */
-module.exports.getUser = (login) => {
-  const users = database.users;
-  const loginAttribute = conf.server.userLoginAttribute;
-  let fetchedUser;
-  let user = {attributes: {}};
+const deduplicate = (entries) => {
+  const unique = [];
+  entries.forEach((entry) => {
+    if (!unique.some((item) => item.dn === entry.dn)) {
+      unique.push(entry);
+    }
+  });
 
-  for (let user in users) {
-    if (users[user][loginAttribute] === login) {
-      fetchedUser = users[user];
-      break;
+  return unique;
+};
+
+const getIntersection = (results) => {
+  if (results.length < 1) {
+    return results;
+  }
+
+  const intersection = results[0];
+  for (const entries of results.slice(1)) {
+    for (const entry of entries) {
+      const idx = intersection.findIndex((item) => item.dn === entry.dn);
+      if (idx === -1) {
+        intersection.splice(idx, 1);
+      }
     }
   }
 
-  if (!fetchedUser) return null;
-
-  user.dn = fetchedUser.dn;
-  for (let propertyName in fetchedUser) {
-    if (propertyName !== 'dn')
-      user.attributes[propertyName] = fetchedUser[propertyName];
-  }
-
-  return user;
+  return intersection;
 };
 
-module.exports.getAllUsers = () => {
+const splitFilter = (filter) => {
+  const parts = [];
+
+  let parenCount = 0;
+  let start = 0;
+  Array.from(filter).forEach((char, i) => {
+    if (char === '(') {
+      parenCount++;
+    } else if (char === ')') {
+      parenCount--;
+    }
+
+    if (parenCount === 0) {
+      parts.push(filter.substring(start, i + 1));
+      start = i + 1;
+    }
+  });
+
+  return parts;
+};
+
+const getAllUsers = () => {
   return database.users.map((user) => {
     const {dn, ...attributes} = user;
     return {dn, attributes};
   });
 };
 
-module.exports.getUsers = (attributeName, searchValue) => {
+const getUsers = (attributeName, searchValue) => {
   return database.users
     .filter((user) => {
       const searchRegex = new RegExp(`^${searchValue.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace('*', '.*')}$`);
@@ -71,3 +86,33 @@ module.exports.getUsers = (attributeName, searchValue) => {
       return {dn, attributes};
     });
 };
+
+/**
+ * Searches the database.
+ *
+ * @method search
+ * @static
+ * @params {String} filter An LDAP search filter
+ * @return {Array<Object>} An array of user objects matching the filter
+ */
+const search = (filter) => {
+  const withoutParens = filter.substring(1, filter.length - 1);
+
+  if (withoutParens.startsWith('&')) {
+    return getIntersection(splitFilter(withoutParens.substring(1)).map(search));
+  } else if (withoutParens.startsWith('|')) {
+    return deduplicate(splitFilter(withoutParens.substring(1)).map(search).flat());
+  } else if (withoutParens.startsWith('!')) {
+    const filteredDns = search(withoutParens.substring(1)).map((user) => user.dn);
+    return getAllUsers().filter((user) => !filteredDns.includes(user.dn));
+  } else {
+    // we do this instead of just .split('=') because filters can have "=" in the values
+    const equalSignIndex = withoutParens.indexOf('=');
+    const attributeName = withoutParens.substring(0, equalSignIndex);
+    const attributeValue = withoutParens.substring(equalSignIndex + 1);
+
+    return getUsers(attributeName, attributeValue);
+  }
+};
+
+module.exports.search = search;

--- a/server.js
+++ b/server.js
@@ -32,7 +32,6 @@ try {
 }
 
 // Set configuration default values
-conf.server.userLoginAttribute = conf.server.userLoginAttribute || 'cn';
 conf.server.searchBase = conf.server.searchBase || 'dc=test';
 conf.server.port = conf.server.port || 3004;
 

--- a/server.js
+++ b/server.js
@@ -33,7 +33,6 @@ try {
 
 // Set configuration default values
 conf.server.userLoginAttribute = conf.server.userLoginAttribute || 'cn';
-conf.server.searchFilter = conf.server.searchFilter || '(&(objectclass=person)(cn={{username}}))';
 conf.server.searchBase = conf.server.searchBase || 'dc=test';
 conf.server.port = conf.server.port || 3004;
 


### PR DESCRIPTION
This implements LDAP filter queries and allows them to be dynamic. The filter no longer needs to be defined in the configuration.

And (`&`), or (`|`), not (`!`), and wildcard (`*`) queries are all supported. Note that the behavior for complex queries may be _slightly_ different than an actual Active Directory instance - the implementation presented in this PR may actually be more robust and support some things (like wildcards in negated queries).

For example, given the following user database:
```json
[
  {
  "dn":"CN=Foo User,OU=USERS,DC=example,DC=com",
  "objectClass":["top","person","organizationalPerson","user"],
  "cn":"Foo User",
  "sn":"User",
  "givenName":"Foo",
  "distinguishedName":"CN=Foo User,OU=USERS,DC=example,DC=com",
  "displayName":"Foo User",
  "memberOf":[
    "CN=GROUP1,DC=example,DC=com",
    "CN=GROUP2,DC=example,DC=com"
  ],
  "name":"Foo User",
  "sAMAccountName":"foo_user",
  "userPrincipalName":"foo@example.com",
  "objectCategory":"CN=Person,CN=Schema,CN=Configuration,DC=example,DC=com",
  "mail":"foo@example.com"
  },
  {
  "dn":"CN=Bar User,OU=USERS,DC=example,DC=com",
  "objectClass":["top","person","organizationalPerson","user"],
  "cn":"Bar User",
  "sn":"User",
  "givenName":"Bar",
  "distinguishedName":"CN=Bar User,OU=USERS,DC=example,DC=com",
  "displayName":"Bar User",
  "memberOf":[
    "CN=GROUP1,DC=example,DC=com",
    "CN=GROUP3,DC=example,DC=com"
  ],
  "name":"Bar User",
  "sAMAccountName":"bar_user",
  "userPrincipalName":"bar@example.com",
  "objectCategory":"CN=Person,CN=Schema,CN=Configuration,DC=example,DC=com",
  "mail":"bar@example.com"
  }
]
```

Here are some examples of valid queries (with their responses):

```shell
$ ldapsearch -x -H ldap://127.0.0.1:3004 -b "dc=hedgeservtest,DC=com" "(sAMAccountName=foo_user)"
# extended LDIF
#
# LDAPv3
# base <dc=hedgeservtest,DC=com> with scope subtree
# filter: (sAMAccountName=foo_user)
# requesting: ALL
#

# Foo User, USERS, example.com
dn: cn=Foo User,ou=USERS,dc=example,dc=com
objectClass: top
objectClass: person
objectClass: organizationalPerson
objectClass: user
cn: Foo User
sn: User
givenName: Foo
distinguishedName: CN=Foo User,OU=USERS,DC=example,DC=com
displayName: Foo User
memberOf: CN=GROUP1,DC=example,DC=com
memberOf: CN=GROUP2,DC=example,DC=com
name: Foo User
sAMAccountName: foo_user
userPrincipalName: foo@example.com
objectCategory: CN=Person,CN=Schema,CN=Configuration,DC=example,DC=com
mail: foo@example.com

# search result
search: 2
result: 0 Success

# numResponses: 2
# numEntries: 1
```

```shell
$ ldapsearch -x -H ldap://127.0.0.1:3004 -b "dc=hedgeservtest,DC=com" "(memberOf=CN=GROUP2,DC=example,DC=com)" -o dn
# extended LDIF
#
# LDAPv3
# base <dc=hedgeservtest,DC=com> with scope subtree
# filter: (memberOf=CN=GROUP2,DC=example,DC=com)
# requesting: -o dn
#

# Foo User, USERS, example.com
dn: cn=Foo User,ou=USERS,dc=example,dc=com

# search result
search: 2
result: 0 Success

# numResponses: 2
# numEntries: 1
```

```shell
$ ldapsearch -x -H ldap://127.0.0.1:3004 -b "dc=hedgeservtest,DC=com" "(|(sAMAccountName=foo_user)(sAMAccountName=bar_user))" -o dn
# extended LDIF
#
# LDAPv3
# base <dc=hedgeservtest,DC=com> with scope subtree
# filter: (|(sAMAccountName=foo_user)(sAMAccountName=bar_user))
# requesting: -o dn
#

# Foo User, USERS, example.com
dn: cn=Foo User,ou=USERS,dc=example,dc=com

# Bar User, USERS, example.com
dn: cn=Bar User,ou=USERS,dc=example,dc=com

# search result
search: 2
result: 0 Success

# numResponses: 3
# numEntries: 2
```


Closes #20 
Closes #9 